### PR TITLE
Download Architecture Specific Tini Release

### DIFF
--- a/result/Dockerfile
+++ b/result/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update \
 
 # Add Tini for proper init of signals
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ARG TARGETARCH
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 
 WORKDIR /app


### PR DESCRIPTION
I am doing the Docker Mastery course assignment to run this app in Swarm and tried running in on some Raspberry Pi's that I have. All services were working except the result service. I saw the error `exec format error` related to running tini when I check the service logs. After some research I found that tini has architecture specific releases. 

https://github.com/krallin/tini/releases

And also this issue where someone reported the same error.

https://github.com/krallin/tini/issues/140

I found this document regarding the `TARGETARCH` argument so I changed the Dockerfile to use that.

https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

I tested it out using `docker build` and `docker buildx`. Both seem to worked in my environment. I pushed it to Docker Hub under my account (jsteinshouer/examplevotingapp_result) to test running it. The image works on windows machine as well as the Raspberry Pi. 

Hope this helps. Thank you for the great course!