### PR TITLE
Example of Compose Sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,18 @@ services:
     build: ./result
     # use nodemon rather than node for local dev
     command: nodemon server.js
+    x-develop:
+      watch:
+        - action: sync
+          path: .
+          target: /app
+        - action: rebuild
+          path: package.json
     depends_on:
       db:
         condition: service_healthy 
-    volumes:
-      - ./result:/app
+    # volumes:
+    #   - ./result:/app
     ports:
       - "5001:80"
       - "5858:5858"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,15 @@ services:
     x-develop:
       watch:
         - action: sync
-          path: .
+          path: ./result
           target: /app
+          ignore:
+            - package.json
+            - Dockerfile
         - action: rebuild
-          path: package.json
+          path: ./result/package.json
+        - action: rebuild
+          path: ./result/Dockerfile
     depends_on:
       db:
         condition: service_healthy 


### PR DESCRIPTION
A new watch feature for Compose will either rebuild an image or copy files into the running container when they change on the host. It's Alpha, but is working great for me so far and completely avoids bind-mounts for code:

The [Blog announcement](https://www.docker.com/blog/docker-compose-experiment-sync-files-and-automatically-rebuild-services-with-watch-mode/), [Docs on how to implement it](https://docs.docker.com/compose/file-watch/), and my [YouTube short explaining it](https://www.youtube.com/shorts/6lUm2eCWlkk).