### PR TITLE
Fixing context path

### DIFF
--- a/.github/workflows/call-docker-build-result.yaml
+++ b/.github/workflows/call-docker-build-result.yaml
@@ -68,7 +68,7 @@ jobs:
       
       ### path to where docker should copy files into image
       ### defaults to root of repository (.)
-      context: result
+      context: "{{defaultContext}}:result"
       
       ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
       # file: Containerfile

--- a/.github/workflows/call-docker-build-vote.yaml
+++ b/.github/workflows/call-docker-build-vote.yaml
@@ -68,7 +68,7 @@ jobs:
       
       ### path to where docker should copy files into image
       ### defaults to root of repository (.)
-      context: vote
+      context: "{{defaultContext}}:vote"
       
       ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
       # file: Containerfile

--- a/.github/workflows/call-docker-build-worker.yaml
+++ b/.github/workflows/call-docker-build-worker.yaml
@@ -68,7 +68,7 @@ jobs:
       
       ### path to where docker should copy files into image
       ### defaults to root of repository (.)
-      context: worker
+      context: "{{defaultContext}}:worker"
       
       ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
       # file: Containerfile


### PR DESCRIPTION
Fixing a reusable workflow call. The docker build-push-action uses "git context" rather than the typical `actions/checkout` to clone the repo for building. When a subdir is needed as the build context in this case, the field has a special format:

`context: "{{defaultContext}}:subdir"`

https://github.com/docker/build-push-action?tab=readme-ov-file#git-context